### PR TITLE
:+1: Zaifのnonce生成を規則をAPIの仕様変更に合わせ改善した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-ruby "2.2.0"
+ruby '>=2.2.0'
 
 gemspec

--- a/lib/kaesen/zaif.rb
+++ b/lib/kaesen/zaif.rb
@@ -8,7 +8,7 @@ require 'bigdecimal'
 module Kaesen
   # Zaif Wrapper Class
   # https://corp.zaif.jp/api-docs/
-  
+
   class Zaif < Market
     @@nonce = 0
 
@@ -332,7 +332,7 @@ module Kaesen
 
     def get_nonce
       pre_nonce = @@nonce
-      next_nonce = Time.now.to_i
+      next_nonce = Time.now.to_f
 
       if next_nonce <= pre_nonce
         @@nonce = pre_nonce + 1


### PR DESCRIPTION
#16 の対応

nonce が小数点以下も扱えるようになったので、機能を改善した。

ついでに、rubyのバーションが2.2.0指定だったので、2.2.0以降対応という形に書き換えました。

2つやってしまったので、反省
