### PR TITLE
CoincheckのURL更新に対応するための修正

### DIFF
--- a/lib/kaesen/bitflyer.rb
+++ b/lib/kaesen/bitflyer.rb
@@ -7,11 +7,11 @@ require 'bigdecimal'
 
 module Kaesen
   # BitFlyer Wrapper Class
-  # https://coincheck.jp/documents/exchange/api?locale=ja
+  # https://lightning.bitflyer.jp/docs?lang=ja
   ## API制限
   ## . Private API は 1 分間に約 200 回を上限とします。
   ## . IP アドレスごとに 1 分間に約 500 回を上限とします。
-  
+
   class Bitflyer < Market
     @@nonce = 0
 

--- a/lib/kaesen/bitflyerfx.rb
+++ b/lib/kaesen/bitflyerfx.rb
@@ -7,11 +7,11 @@ require 'bigdecimal'
 
 module Kaesen
   # BitFlyer FX Wrapper Class
-  # https://coincheck.jp/documents/exchange/api?locale=ja
+  # https://lightning.bitflyer.jp/docs?lang=ja
   ## API制限
   ## . Private API は 1 分間に約 200 回を上限とします。
   ## . IP アドレスごとに 1 分間に約 500 回を上限とします。
-  
+
   class Bitflyerfx < Bitflyer
     def initialize
       super()

--- a/lib/kaesen/coincheck.rb
+++ b/lib/kaesen/coincheck.rb
@@ -6,7 +6,7 @@ require 'bigdecimal'
 
 module Kaesen
   # Coincheck Wrapper Class
-  # https://coincheck.jp/documents/exchange/api?locale=ja
+  # https://coincheck.com/documents/exchange/api?locale=ja
 
   class Coincheck < Market
     @@nonce = 0
@@ -16,7 +16,7 @@ module Kaesen
       @name        = "Coincheck"
       @api_key     = ENV["COINCHECK_KEY"]
       @api_secret  = ENV["COINCHECK_SECRET"]
-      @url_public  = "https://coincheck.jp"
+      @url_public  = "https://coincheck.com"
       @url_private = @url_public
     end
 


### PR DESCRIPTION
#15 対応です。

おなじくurl関係で、Bitflyerのドキュメントのアドレスが間違っていたので合わせて修正しました。
